### PR TITLE
Stop the std_list cache drifting from the database

### DIFF
--- a/Source/Process.ts
+++ b/Source/Process.ts
@@ -50,12 +50,10 @@ function sleep(time: number) {
 // hot read - costs no database rows.
 export const StdListKey = "std_list";
 
-// Tolerates the legacy trailing-newline format, a missing key, and any blank
-// lines left behind by earlier writes.
-export const ParseStdList = (Cached: string | null | undefined): Array<number> => {
-  if (!Cached) {
-    return [];
-  }
+// Tolerates the legacy trailing-newline format and any blank lines left behind
+// by earlier writes. An empty string is a legitimately empty cache; a missing
+// key is not, and callers must handle that before getting here.
+export const ParseStdList = (Cached: string): Array<number> => {
   return Cached.split("\n")
     .filter((Entry) => Entry.trim() !== "")
     .map(Number);
@@ -1223,7 +1221,8 @@ export class Process {
         // This is the hot path - the script calls UploadStd for problems that
         // already have a std. Only touch the database when the cache is
         // actually missing this problem, which is the drift we are repairing.
-        if (!ParseStdList(await this.kv.get(StdListKey)).includes(ProblemID)) {
+        const Cached = await this.kv.get(StdListKey);
+        if (Cached === null || Cached === undefined || !ParseStdList(Cached).includes(ProblemID)) {
           await RebuildStdList(this.XMOJDatabase, this.kv);
         }
         return new Result(true, "此题已经有人上传标程");
@@ -1328,7 +1327,15 @@ export class Process {
       const ResponseData = {
         StdList: new Array<number>()
       };
-      ResponseData.StdList = ParseStdList(await this.kv.get(StdListKey));
+      // A missing key is not an empty list - it means the cache has never been
+      // built, and answering [] would tell the client that no problem has a std
+      // answer. Fill it from the database instead. An empty string is a real
+      // empty cache and is served as-is, so this costs a scan only on a genuine
+      // miss, which the daily rebuild keeps rare.
+      const Cached = await this.kv.get(StdListKey);
+      ResponseData.StdList = ParseStdList(
+        Cached ?? await RebuildStdList(this.XMOJDatabase, this.kv)
+      );
       return new Result(true, "获得标程列表成功", ResponseData);
     },
     GetStd: async (Data: object): Promise<Result> => {

--- a/Source/Process.ts
+++ b/Source/Process.ts
@@ -45,6 +45,34 @@ function sleep(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time));
 }
 
+// The KV key holding the list of problems that have a std answer. It is a
+// cache of `SELECT problem_id FROM std_answer`, kept so that GetStdList - a
+// hot read - costs no database rows.
+export const StdListKey = "std_list";
+
+// Tolerates the legacy trailing-newline format, a missing key, and any blank
+// lines left behind by earlier writes.
+export const ParseStdList = (Cached: string | null | undefined): Array<number> => {
+  if (!Cached) {
+    return [];
+  }
+  return Cached.split("\n")
+    .filter((Entry) => Entry.trim() !== "")
+    .map(Number);
+};
+
+// Rewrites the cache from the database. Rebuilding wholesale rather than
+// patching an entry in means a dropped or racing write can only ever cost
+// freshness until the next rebuild, never permanent drift.
+export const RebuildStdList = async (XMOJDatabase: Database, kv: KVNamespace): Promise<string> => {
+  const Rows = ThrowErrorIfFailed(
+    await XMOJDatabase.Select("std_answer", ["problem_id"])
+  ) as Array<Record<string, any>>;
+  const List = Rows.map((Row) => Row["problem_id"]).join("\n");
+  await kv.put(StdListKey, List);
+  return List;
+};
+
 export class Process {
   private AdminUserList: Array<string> = ["chenlangning", "shanwenxiao", "zhuchenrui2","liushangchen"];
   // noinspection JSMismatchedCollectionQueryUpdate
@@ -1192,13 +1220,12 @@ export class Process {
       if (ThrowErrorIfFailed(await this.XMOJDatabase.GetTableSize("std_answer", {
         problem_id: ProblemID
       }))["TableSize"] !== 0) {
-        let currentStdList = await this.kv.get("std_list");
-        console.log(currentStdList.toString().indexOf(Data["ProblemID"].toString()));
-        if (currentStdList.split('\n').some(d => d === Data["ProblemID"])) {
-          currentStdList = currentStdList + Data["ProblemID"] + "\n";
-          this.kv.put("std_list", currentStdList);
+        // This is the hot path - the script calls UploadStd for problems that
+        // already have a std. Only touch the database when the cache is
+        // actually missing this problem, which is the drift we are repairing.
+        if (!ParseStdList(await this.kv.get(StdListKey)).includes(ProblemID)) {
+          await RebuildStdList(this.XMOJDatabase, this.kv);
         }
-        console.log("ProblemID: " + ProblemID + " already has a std answer, skipping upload.");
         return new Result(true, "此题已经有人上传标程");
       }
       if (await this.GetProblemScoreChecker(ProblemID) !== 100) {
@@ -1289,9 +1316,11 @@ export class Process {
         problem_id: Data["ProblemID"],
         std_code: StdCode
       }));
-      let currentStdList = await this.kv.get("std_list");
-      currentStdList = currentStdList + Data["ProblemID"] + "\n";
-      this.kv.put("std_list", currentStdList);
+      // Rebuild from the database rather than appending to the cached string:
+      // an append races with concurrent uploads (KV has no compare-and-set) and
+      // silently loses entries. Uploads are bounded at one per problem ever, so
+      // the extra scan is affordable here in a way it would not be on reads.
+      await RebuildStdList(this.XMOJDatabase, this.kv);
       return new Result(true, "标程上传成功");
     },
     GetStdList: async (Data: object): Promise<Result> => {
@@ -1299,7 +1328,7 @@ export class Process {
       const ResponseData = {
         StdList: new Array<number>()
       };
-      ResponseData.StdList = (await this.kv.get("std_list")).split("\n").map(Number);
+      ResponseData.StdList = ParseStdList(await this.kv.get(StdListKey));
       return new Result(true, "获得标程列表成功", ResponseData);
     },
     GetStd: async (Data: object): Promise<Result> => {

--- a/Source/index.ts
+++ b/Source/index.ts
@@ -15,7 +15,7 @@
  *     along with XMOJ-bbs.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {Process} from "./Process";
+import {Process, RebuildStdList} from "./Process";
 import {Database} from "./Database";
 import {NotificationManager} from "./NotificationManager";
 import type {D1Database, KVNamespace, AnalyticsEngineDataset, DurableObjectNamespace, Ai} from "@cloudflare/workers-types";
@@ -152,7 +152,7 @@ export default {
     let Processor = new Process(RequestData, Environment);
     return addCorsHeaders(await Processor.Process(), origin);
   },
-  async scheduled(Event: any, Environment: { DB: D1Database; }, Context: {
+  async scheduled(Event: any, Environment: { DB: D1Database; kv: KVNamespace; }, Context: {
     waitUntil: (arg0: Promise<void>) => void;
   }) {
     let XMOJDatabase = new Database(Environment.DB);
@@ -173,6 +173,10 @@ export default {
           "Value": new Date().getTime() - 1000 * 60 * 60 * 24 * 5
         }
       });
+      // Reconcile the std list cache against the database. One scan per day
+      // bounds any drift - from a dropped KV write or two uploads racing - to
+      // 24 hours, instead of it persisting forever as it does today.
+      await RebuildStdList(XMOJDatabase, Environment.kv);
       Resolve();
     }));
   },

--- a/Source/index.ts
+++ b/Source/index.ts
@@ -156,7 +156,12 @@ export default {
     waitUntil: (arg0: Promise<void>) => void;
   }) {
     let XMOJDatabase = new Database(Environment.DB);
-    Context.waitUntil(new Promise<void>(async (Resolve) => {
+    // An async function passed as a Promise executor swallows its own
+    // rejection - the constructor discards the returned promise, so a throw
+    // from ThrowErrorIfFailed would leave this pending forever and waitUntil
+    // would hang instead of reporting the failed run. Hand waitUntil the async
+    // call's promise directly so errors propagate.
+    Context.waitUntil((async () => {
       await XMOJDatabase.Delete("short_message", {
         "send_time": {
           "Operator": "<=",
@@ -177,7 +182,6 @@ export default {
       // bounds any drift - from a dropped KV write or two uploads racing - to
       // 24 hours, instead of it persisting forever as it does today.
       await RebuildStdList(XMOJDatabase, Environment.kv);
-      Resolve();
-    }));
+    })());
   },
 };

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -809,12 +809,51 @@ test('GetStdList returns no spurious trailing zero', async () => {
     assert.deepStrictEqual(result.Data.StdList, [1000, 1001, 1002]);
 });
 
-test('GetStdList handles an unset cache key', async () => {
-    const proc = createProcess();
-    proc.kv = kvStub(undefined);
+test('GetStdList fills the cache from the database when the key is unset', async () => {
+    // An unset key is not an empty list - answering [] would tell the client
+    // that no problem has a std answer at all.
+    const kv = kvStub(undefined);
+    const proc = createProcess({
+        db: {
+            Select: async () => new Result(true, '', [
+                { problem_id: 1000 }, { problem_id: 1001 }
+            ])
+        }
+    });
+    proc.kv = kv;
+
+    const result = await proc.ProcessFunctions['GetStdList']({});
+
+    assert.ok(result.Success);
+    assert.deepStrictEqual(result.Data.StdList, [1000, 1001]);
+    assert.strictEqual(kv.store.std_list, '1000\n1001', 'cache filled for next time');
+});
+
+test('GetStdList serves an empty cache without touching the database', async () => {
+    // An empty string is a legitimately empty cache (no stds uploaded yet) and
+    // must be distinguished from a missing key.
+    const select = test.mock.fn(async () => new Result(true, '', []));
+    const proc = createProcess({ db: { Select: select } });
+    proc.kv = kvStub('');
 
     const result = await proc.ProcessFunctions['GetStdList']({});
 
     assert.ok(result.Success);
     assert.deepStrictEqual(result.Data.StdList, []);
+    assert.strictEqual(select.mock.calls.length, 0, 'empty cache is valid, no rebuild');
+});
+
+test('UploadStd rebuilds when the cache key is unset entirely', async () => {
+    const kv = kvStub(undefined);
+    const proc = createProcess({
+        db: {
+            GetTableSize: async () => new Result(true, '', { TableSize: 1 }),
+            Select: async () => new Result(true, '', [{ problem_id: 1234 }]),
+        }
+    });
+    proc.kv = kv;
+
+    await proc.ProcessFunctions['UploadStd']({ ProblemID: 1234 });
+
+    assert.strictEqual(kv.store.std_list, '1234');
 });

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -664,3 +664,159 @@ test('GetPost clears mentions for the reader', async () => {
 
     assert.deepStrictEqual(deleted, [{ table: 'bbs_mention', where: { post_id: 1, to_user_id: 'testuser' } }]);
 });
+
+// --- std_list KV cache ---------------------------------------------------
+// The cache is a denormalised copy of `SELECT problem_id FROM std_answer`.
+// It is rebuilt wholesale from the database rather than patched incrementally,
+// so a dropped or racing write cannot leave it permanently out of sync.
+
+const { RebuildStdList } = require('../Source/Process.ts');
+
+function kvStub(initial) {
+    const store = { std_list: initial };
+    const puts = [];
+    return {
+        store,
+        puts,
+        get: async (key) => (key in store ? store[key] : null),
+        put: async (key, value) => { store[key] = value; puts.push(value); },
+    };
+}
+
+test('RebuildStdList writes every problem_id from the database', async () => {
+    const kv = kvStub('stale\n');
+    const db = {
+        Select: async (table, columns) => {
+            assert.strictEqual(table, 'std_answer');
+            assert.deepStrictEqual(columns, ['problem_id']);
+            return new Result(true, '', [
+                { problem_id: 1000 }, { problem_id: 1001 }, { problem_id: 1002 }
+            ]);
+        }
+    };
+
+    const list = await RebuildStdList(db, kv);
+
+    assert.strictEqual(list, '1000\n1001\n1002');
+    assert.strictEqual(kv.store.std_list, '1000\n1001\n1002');
+});
+
+test('RebuildStdList writes an empty cache when the table is empty', async () => {
+    const kv = kvStub('1000\n1001\n');
+    const db = { Select: async () => new Result(true, '', []) };
+
+    await RebuildStdList(db, kv);
+
+    assert.strictEqual(kv.store.std_list, '');
+});
+
+test('RebuildStdList heals a cache that has drifted from the database', async () => {
+    // 1001 was dropped by a lost write; 9999 was never in the table.
+    const kv = kvStub('1000\n9999\n');
+    const db = {
+        Select: async () => new Result(true, '', [
+            { problem_id: 1000 }, { problem_id: 1001 }, { problem_id: 1002 }
+        ])
+    };
+
+    await RebuildStdList(db, kv);
+
+    assert.strictEqual(kv.store.std_list, '1000\n1001\n1002');
+});
+
+const STD_CODE_MARKER = '/' + '*'.repeat(62);
+
+// Minimal pages that satisfy the XMOJ scraper in UploadStd.
+function stdScraperFetch() {
+    const statusPage = `<table id="problemstatus">
+        <thead><tr><th>#</th><th>SID</th><th>user</th></tr></thead>
+        <tbody>
+          <tr><td>1</td><td>1</td><td>someone</td></tr>
+          <tr><td>2</td><td>555</td><td>std</td></tr>
+        </tbody>
+      </table>[NEXT]`;
+    const sourcePage = `int main(){}\n${STD_CODE_MARKER}\ntrailer\n<!--not cached-->`;
+    return async (url) => new Response(
+        String(url).includes('getsource.php') ? sourcePage : statusPage
+    );
+}
+
+test('UploadStd rebuilds and awaits the cache after inserting a std', async () => {
+    const kv = kvStub('1000\n');
+    const proc = createProcess({
+        db: {
+            GetTableSize: async () => new Result(true, '', { TableSize: 0 }),
+            Insert: async () => new Result(true, '', { InsertID: 1 }),
+            Select: async () => new Result(true, '', [{ problem_id: 1000 }, { problem_id: 1234 }]),
+        }
+    });
+    proc.kv = kv;
+    proc.GetProblemScoreChecker = async () => 100;
+    proc.Fetch = stdScraperFetch();
+
+    const result = await proc.ProcessFunctions['UploadStd']({ ProblemID: 1234 });
+
+    assert.ok(result.Success, result.Message);
+    assert.strictEqual(kv.puts.length, 1, 'cache written exactly once');
+    assert.strictEqual(kv.store.std_list, '1000\n1234',
+        'cache must reflect the database once UploadStd resolves');
+});
+
+test('UploadStd repairs a cache missing an already-uploaded problem', async () => {
+    // The DB already has a std for 1234 but the cache lost it. Re-uploading
+    // must put it back rather than silently doing nothing.
+    const kv = kvStub('1000\n');
+    const proc = createProcess({
+        db: {
+            GetTableSize: async () => new Result(true, '', { TableSize: 1 }),
+            Select: async () => new Result(true, '', [{ problem_id: 1000 }, { problem_id: 1234 }]),
+        }
+    });
+    proc.kv = kv;
+
+    const result = await proc.ProcessFunctions['UploadStd']({ ProblemID: 1234 });
+
+    assert.ok(result.Success);
+    assert.strictEqual(result.Message, '此题已经有人上传标程');
+    assert.strictEqual(kv.store.std_list, '1000\n1234');
+});
+
+test('UploadStd touches neither database nor cache when already in sync', async () => {
+    // The hot path: the script re-uploads a problem that already has a std and
+    // is already cached. This must cost zero database rows and zero KV writes.
+    const kv = kvStub('1000\n1234\n');
+    const select = test.mock.fn(async () => new Result(true, '', []));
+    const proc = createProcess({
+        db: {
+            GetTableSize: async () => new Result(true, '', { TableSize: 1 }),
+            Select: select,
+        }
+    });
+    proc.kv = kv;
+
+    await proc.ProcessFunctions['UploadStd']({ ProblemID: 1234 });
+
+    assert.strictEqual(select.mock.calls.length, 0, 'no database read on the hot path');
+    assert.strictEqual(kv.puts.length, 0, 'no cache write on the hot path');
+    assert.strictEqual(kv.store.std_list, '1000\n1234\n', 'cache left untouched');
+});
+
+test('GetStdList returns no spurious trailing zero', async () => {
+    const proc = createProcess();
+    proc.kv = kvStub('1000\n1001\n1002\n');   // legacy trailing-newline format
+
+    const result = await proc.ProcessFunctions['GetStdList']({});
+
+    assert.ok(result.Success);
+    assert.deepStrictEqual(result.Data.StdList, [1000, 1001, 1002]);
+});
+
+test('GetStdList handles an unset cache key', async () => {
+    const proc = createProcess();
+    proc.kv = kvStub(undefined);
+
+    const result = await proc.ProcessFunctions['GetStdList']({});
+
+    assert.ok(result.Success);
+    assert.deepStrictEqual(result.Data.StdList, []);
+});

--- a/test/process.test.js
+++ b/test/process.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { Process } = require('../Source/Process.ts');
+const { Process, RebuildStdList } = require('../Source/Process.ts');
 const { Result } = require('../Source/Result.ts');
 
 function createProcess(mocks = {}) {
@@ -669,8 +669,6 @@ test('GetPost clears mentions for the reader', async () => {
 // The cache is a denormalised copy of `SELECT problem_id FROM std_answer`.
 // It is rebuilt wholesale from the database rather than patched incrementally,
 // so a dropped or racing write cannot leave it permanently out of sync.
-
-const { RebuildStdList } = require('../Source/Process.ts');
 
 function kvStub(initial) {
     const store = { std_list: initial };


### PR DESCRIPTION
The `std_list` KV cache kept losing problems that exist in `std_answer`. Three separate defects combined, which is why it looked intermittent and random.

## 1. The KV write was a floating promise

`Source/Process.ts`, upload path:

```ts
ThrowErrorIfFailed(await this.XMOJDatabase.Insert("std_answer", {...}));  // awaited
this.kv.put("std_list", currentStdList);                                  // NOT awaited
return new Result(true, "标程上传成功");
```

The D1 insert commits; the KV put has nothing keeping it alive. `Source/index.ts` accepts `Context` in `fetch` but never uses it — `waitUntil` appears nowhere outside the cron handler, and `Process` is constructed as `new Process(RequestData, Environment)`, so it has no access to the execution context at all. Once the response returns, the pending KV write is not guaranteed to complete.

## 2. Read-modify-write over a store with no compare-and-set

Every upload did `get` → concat → `put` of the **entire** list. Two uploads landing close together both read the same base list, each appended only its own id, and the second `put` overwrote the first — that id gone permanently. KV reads are also eventually consistent, so even non-concurrent uploads from different locations could read a stale list and clobber newer entries.

## 3. The self-repair branch was dead code

The branch meant to backfill a missing entry, reduced to a runnable repro:

```
split -> ["1000","1001","1002",""]
typeof element: string | typeof ProblemID: number
branch taken for an ID that IS present (1001): false
branch taken for an ID that is MISSING (9999): false
```

`split('\n')` yields strings; `CheckParams` guarantees `ProblemID` is a number. `d === Data["ProblemID"]` is strict equality across types — always false, for every input. The condition was **also** inverted:

```
with the type mismatch removed:
  present (1001) -> appends again?  true
  missing (9999) -> appends?        false
```

It appended when the id was already there and did nothing when it was missing. Two bugs cancelling into a no-op — so fixing only the type comparison would have made it worse, appending a duplicate on every re-upload.

Net effect: 1 and 2 removed entries, 3 guaranteed they were never restored. Drift was one-directional and permanent.

## The fix

Rebuild the cache wholesale from the database rather than patching entries into it.

- **Reads unchanged.** `GetStdList` is still a pure KV read costing zero database rows — that is why the cache exists.
- **Insert path** rebuilds from D1 and awaits the write. `UploadStd` early-returns when a std already exists, so a problem is inserted at most once ever; lifetime inserts are bounded by the problem count.
- **Already-uploaded path stays cheap.** This is the hot one, so it rebuilds *only* when the cached list is genuinely missing the problem. A test asserts zero DB reads and zero KV writes when the cache is already in sync.
- **Daily reconciliation** in the existing cron (`crons = ["0 0 * * *"]`, which already has a proper `waitUntil`). One scan per day bounds any remaining drift to 24 hours instead of forever. This is the part that does not depend on every write path staying correct in the future.

Also fixes `GetStdList` returning a spurious trailing `0` from the trailing newline (`[1000, 1001, 1002, 0]`), and throwing outright if the key were ever unset.

## Verification

9 tests added, written before the fix and confirmed failing against the old code (including the unset-key crash at the then-current `Process.ts:1283`). All pass now; full suite 56 pass, 0 fail. The changed regions are clean under `tsc --noEmit`; the one remaining `index.ts` error is pre-existing on master, verified by stashing.

Coverage includes drift healing, the empty table, the hot path doing no I/O, cache repair on re-upload, and both the legacy trailing-newline and unset-key read formats.

## Note

The rebuild-on-write still has a narrow window — KV put ordering is not guaranteed, so two concurrent uploads could in principle land out of order. Each writer now writes complete state rather than a delta, so the loss is far smaller, and the daily rebuild bounds it. Closing it entirely would need the list moved into D1 or a Durable Object, which is a bigger change than this bug warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the `std_list` KV cache from D1 to stop drift, awaits writes, and reconciles it daily. `GetStdList` now rebuilds on a missing key (not empty) and ignores trailing newlines; cron failures now propagate.

- **Bug Fixes**
  - Replace racy read→append→put with wholesale rebuilds; await KV writes.
  - Hot path only rebuilds when the cached list truly misses the problem.
  - `GetStdList` rebuilds the cache on a missing key and parses legacy trailing newlines.
  - Scheduled job hands `waitUntil` a real async promise and runs `RebuildStdList`, so failures are reported and drift heals within 24 hours.

- **Refactors**
  - Add `StdListKey`, `ParseStdList`, and `RebuildStdList`; `GetStdList` remains a pure KV read on hits, doing no DB/KV work when in sync.

<sup>Written for commit f8378f20773da4bc4e58bead1b837b76bfb9b114. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/XMOJ-Script-dev/XMOJ-bbs/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Rebuild the std_list KV cache from the database to prevent drift and ensure consistent std answer listings, with periodic reconciliation via the scheduled worker.

Bug Fixes:
- Ensure UploadStd rebuilds and awaits the std_list KV cache after inserts instead of performing racy append writes.
- Prevent UploadStd from silently ignoring already-uploaded problems that are missing from the cache by repairing the cache when it is out of sync.
- Handle unset std_list KV keys and legacy trailing-newline formats in GetStdList so it no longer crashes or returns a spurious trailing zero.
- Fix the scheduled handler so async errors propagate correctly instead of being swallowed by an improperly constructed Promise.

Enhancements:
- Introduce StdListKey, ParseStdList, and RebuildStdList helpers to centralize management of the std_list KV cache and tolerate legacy formats.
- Optimize the hot re-upload path to avoid unnecessary database reads and KV writes when the cache is already in sync.
- Add a daily reconciliation step in the scheduled job to rebuild the std_list cache from the database and bound any remaining drift.

Tests:
- Add comprehensive tests for std_list cache rebuilding, drift healing, and empty-table behavior.
- Add tests ensuring UploadStd correctly rebuilds/repairs the cache, avoids redundant I/O on the hot path, and handles unset cache keys.
- Add tests validating GetStdList parsing of cached data, distinguishing between empty and missing keys, and avoiding extra database access when the cache is valid.